### PR TITLE
minor improvements

### DIFF
--- a/JASwipeCell/JASwipeCell.h
+++ b/JASwipeCell/JASwipeCell.h
@@ -38,11 +38,11 @@ typedef NS_OPTIONS(NSUInteger, JAButtonLocation) {
 @class JASwipeCell;
 
 @protocol JASwipeCellDelegate <NSObject>
+@optional
 // Called when the left most button has swiped all the way to the right.
 - (void)leftMostButtonSwipeCompleted:(JASwipeCell *)cell;
 // Called when the right most button has swiped all the way to the left.
 - (void)rightMostButtonSwipeCompleted:(JASwipeCell *)cell;
-@optional
 // Called when the user begins swiping right on the cell.
 - (void)swipingRightForCell:(JASwipeCell *)cell;
 // Called when the user begins swiping left on the cell.

--- a/JASwipeCell/JASwipeCell.m
+++ b/JASwipeCell/JASwipeCell.m
@@ -80,6 +80,12 @@ typedef NS_ENUM(NSUInteger, JASwipeDirection) {
     return self;
 }
 
+- (void) awakeFromNib
+{
+    [super awakeFromNib];
+    [self initialize];
+}
+
 - (void)initialize
 {
     [self addSubview:self.topContentView];

--- a/JASwipeCell/JASwipeCell.m
+++ b/JASwipeCell/JASwipeCell.m
@@ -441,7 +441,9 @@ typedef NS_ENUM(NSUInteger, JASwipeDirection) {
                     [UIView animateWithDuration:0.1 delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
                         [self pinButtonToTopViewWithOffset:newXOffset swipeDirection:JASwipeDirectionLeft];
                     } completion:^(BOOL finished) {
-                        [self.delegate rightMostButtonSwipeCompleted:self];
+                        if ([self.delegate respondsToSelector:@selector(rightMostButtonSwipeCompleted:)]) {
+                            [self.delegate rightMostButtonSwipeCompleted:self];
+                        }
                     }];
                     self.rightButtonsRevealed = NO;
                 }
@@ -478,7 +480,9 @@ typedef NS_ENUM(NSUInteger, JASwipeDirection) {
                     [UIView animateWithDuration:0.1 delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
                         [self pinButtonToTopViewWithOffset:newXOffset swipeDirection:JASwipeDirectionRight];
                     } completion:^(BOOL finished) {
-                        [self.delegate leftMostButtonSwipeCompleted:self];
+                        if ([self.delegate respondsToSelector:@selector(leftMostButtonSwipeCompleted:)]) {
+                            [self.delegate leftMostButtonSwipeCompleted:self];
+                        }
                     }];
                     self.leftButtonsRevealed = NO;
                 }


### PR DESCRIPTION
When setting up a table view cell in a storyboard or xib file, `initWithStyle:` isn't called and therefore `initialize` is missed. I've added `awakeFromNib:` to invoke initialize as an alternative. 
In addition, to suppress warnings about required `JASwipeCellDelegate` methods, I've declared all delegate methods optional. This is a suggestion, of-course. I didn't see a need to make the methods required.
